### PR TITLE
食事ジャンルの追加

### DIFF
--- a/app/controllers/admin/onsens_controller.rb
+++ b/app/controllers/admin/onsens_controller.rb
@@ -65,6 +65,6 @@ class Admin::OnsensController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def onsen_params
-      params.expect(onsen: [ :name, :geo_lat, :geo_lng, :description, :tags, :pet, images: [] ])
+      params.expect(onsen: [ :name, :geo_lat, :geo_lng, :description, :tags, :pet, :style, images: [] ])
     end
 end

--- a/app/models/onsen.rb
+++ b/app/models/onsen.rb
@@ -4,7 +4,7 @@ class Onsen < ApplicationRecord
   has_many_attached :images
 
   validates :name, presence: true
-
+  enum :style, { japanese: 0, western: 1 }
   validates :images,
   content_type: [ "image/jpeg", "image/png", "image/gif" ], # 許可ファイル形式
   size: { less_than: 5.megabytes },                       # 1枚あたり5MB未満

--- a/app/views/admin/onsens/_form.html.erb
+++ b/app/views/admin/onsens/_form.html.erb
@@ -37,6 +37,13 @@
     <%= form.label :pet, "同伴可能" %>
   </div>
   <div>
+    <%= form.label :style, "ジャンル", class: 'block font-semibold mb-1' %>
+    <%= form.label :style_japanese, "和食" %>
+    <%= form.radio_button :style, "japanese" %>
+    <%= form.label :style_western, "洋食" %>
+    <%= form.radio_button :style, "western" %>
+  </div>
+  <div>
     <%= form.label :images, '画像（最大5枚・JPEG/PNG/GIF）', class: 'block font-semibold mb-1' %>
     <%= form.file_field :images, multiple: true, accept: 'image/jpeg,image/png,image/gif', class: "block border rounded px-2 py-1 w-full" %>
     <% if onsen.images.attached? %>

--- a/app/views/admin/onsens/_onsen.html.erb
+++ b/app/views/admin/onsens/_onsen.html.erb
@@ -11,8 +11,10 @@
   <dd><%= onsen.tags %></dd>
   <dt class="font-semibold">ペット</dt>
   <%if onsen.pet%>
-  <dd>同伴可能</dd>
+    <dd>同伴可能</dd>
   <%else%>
-  <dd>同伴不可</dd>
+    <dd>同伴不可</dd>
   <% end %>
+  <dt class="font-semibold">食事スタイル</dt>
+  <dd><%= onsen.style.present? ? t("enums.style.#{onsen.style}") : "未設定" %></dd>
 </dl>

--- a/app/views/onsens/_spot_card.html.erb
+++ b/app/views/onsens/_spot_card.html.erb
@@ -22,13 +22,19 @@
           <span class="text-xs text-gray-400">未評価</span>
         <% end %>
       </div>
-        <div class="text-xs text-gray-500 mb-2">
-      <% if onsen.pet.present? %>
-          <span class="font-medium">ペット✅</span> 
+      <div class="text-xs text-gray-500 mb-2">
+        <% if onsen.pet.present? %>
+          <span class="font-medium">ペット✅</span>
         <% else %>
-          <span class="font-medium">ペット☒</span> 
-      <% end %>
-        </div>
+          <span class="font-medium">ペット☒</span>
+        <% end %>
+        <% if onsen.style.present? %>
+          <div class="text-xs text-gray-500 mb-2">
+            <span class="font-medium">食事スタイル:</span>
+            <%= t("enums.style.#{onsen.style}") %>
+          </div>
+        <% end %>
+      </div>
     </div>
   </div>
 <% end %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -15,6 +15,10 @@ ja:
         rating: 評価
         comment: コメント
         images: 画像
+  enums:
+    style:
+      japanese: "和食"
+      western: "洋食"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/db/migrate/20250826122458_add_style_to_onsens.rb
+++ b/db/migrate/20250826122458_add_style_to_onsens.rb
@@ -1,0 +1,5 @@
+class AddStyleToOnsens < ActiveRecord::Migration[8.0]
+  def change
+    add_column :onsens, :style, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_26_061602) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_26_122458) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -51,6 +51,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_26_061602) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "pet"
+    t.integer "foodstale"
+    t.integer "foodstyle"
+    t.integer "style"
   end
 
   create_table "reviews", force: :cascade do |t|


### PR DESCRIPTION
enum型で食事ジャンルを保存するstyleを追加（DBはinteger型）japanese:0, western:1
ja.ymlにjapanese:和食 western:洋食　と設定
管理画面の情報追加・変更にジャンルを選ぶラジオボタンを追加
ジャンルを表示するように管理画面・公開画面を変更（管理画面：未設定なら未設定と表示　公開画面：未設定なら表示なし