### PR TITLE
URLの入力と詳細画面での表示の追加

### DIFF
--- a/app/controllers/admin/onsens_controller.rb
+++ b/app/controllers/admin/onsens_controller.rb
@@ -65,6 +65,6 @@ class Admin::OnsensController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def onsen_params
-      params.expect(onsen: [ :name, :geo_lat, :geo_lng, :description, :tags, :pet, :style, images: [] ])
+      params.expect(onsen: [ :name, :geo_lat, :geo_lng, :description, :tags, :pet, :style, :url, images: [] ])
     end
 end

--- a/app/views/admin/onsens/_form.html.erb
+++ b/app/views/admin/onsens/_form.html.erb
@@ -32,6 +32,10 @@
     <%= form.text_field :tags, class: "block shadow-sm rounded-md border px-3 py-2 w-full border-gray-300 focus:outline-blue-600" %>
   </div>
   <div>
+    <%= form.label :url, 'URL', class: 'block font-semibold mb-1' %>
+    <%= form.text_field :url, class: "block shadow-sm rounded-md border px-3 py-2 w-full border-gray-300 focus:outline-blue-600" %>
+  </div>
+  <div>
     <%= form.label :pet, 'ペット', class: 'block font-semibold mb-1' %>
     <%= form.check_box :pet %>
     <%= form.label :pet, "同伴可能" %>

--- a/app/views/admin/onsens/_onsen.html.erb
+++ b/app/views/admin/onsens/_onsen.html.erb
@@ -17,4 +17,8 @@
   <% end %>
   <dt class="font-semibold">食事スタイル</dt>
   <dd><%= onsen.style.present? ? t("enums.style.#{onsen.style}") : "未設定" %></dd>
+  <dt class="font-semibold">URL</dt>
+  <% if onsen.url.present? %>
+  <dd><a href="<%= onsen.url %>" ><%= onsen.url %></a></dd>
+<% end %>
 </dl>

--- a/app/views/onsens/show.html.erb
+++ b/app/views/onsens/show.html.erb
@@ -11,7 +11,11 @@
     <div class="flex flex-col lg:flex-row lg:items-start lg:justify-between mb-6">
       <div class="flex-1">
         <h1 class="text-3xl font-bold text-gray-900 mb-2">
-          <%= @onsen.name %>
+          <% if @onsen.url.present? %>
+            <a href="<%= @onsen.url %>"><%= @onsen.name %></a>
+          <%else%>
+            <%= onsen.name %>
+          <% end %>
           <span class="text-gray-600 text-lg font-normal">
             （<%= @onsen.reviews.count %>件のレビュー）
           </span>
@@ -88,7 +92,7 @@
   </div>
 
   <div class="mt-6">
-    <%= link_to "温泉一覧に戻る", onsens_path, 
+    <%= link_to "店舗一覧に戻る", onsens_path, 
         class: "inline-flex items-center px-4 py-2 border border-gray-300 text-gray-700 rounded-md hover:bg-gray-50" %>
   </div>
 </div>


### PR DESCRIPTION
* 店舗追加フォームにURL入力欄を追加
* 検索結果カードから開ける詳細ページにてURLを店舗名に埋め込み