### PR TITLE
営業時間フィルターの追加等

### DIFF
--- a/app/controllers/admin/onsens_controller.rb
+++ b/app/controllers/admin/onsens_controller.rb
@@ -8,6 +8,7 @@ class Admin::OnsensController < ApplicationController
 
   # GET /onsens/1 or /onsens/1.json
   def show
+  @onsen = Onsen.find(params[:id])
   end
 
   # GET /onsens/new
@@ -65,6 +66,6 @@ class Admin::OnsensController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def onsen_params
-      params.expect(onsen: [ :name, :geo_lat, :geo_lng, :description, :tags, :pet, :style, :url, :weekday_hours, :weekend_hours, :holiday, :parking, images: [] ])
+      params.expect(onsen: [ :name, :geo_lat, :geo_lng, :description, :tags, :pet, :style, :url, :weekday_hours, :weekday_open_time, :weekday_close_time, :weekend_hours, :weekend_open_time, :weekend_close_time, :holiday, holiday: [], images: [] ])
     end
 end

--- a/app/controllers/onsens_controller.rb
+++ b/app/controllers/onsens_controller.rb
@@ -3,7 +3,7 @@ class OnsensController < ApplicationController
   # GET /onsens or /onsens.json
   def index
     # Strong Parametersで安全なパラメータのみ許可
-    @search_params = params.permit(:q, :tags, :pet, :style)
+    @search_params = params.permit(:q, :tags, :pet, :style, :search_time, :open_day)
     # モデルの検索メソッドを呼び出し、新しい順でソート
     @onsens = Onsen.search(@search_params).order(created_at: :desc)
   end

--- a/app/views/admin/onsens/_form.html.erb
+++ b/app/views/admin/onsens/_form.html.erb
@@ -46,18 +46,49 @@
     <%= form.label :style_japanese, "和" %>
     <%= form.radio_button :style, "western", class: "ml-4" %>
     <%= form.label :style_western, "洋" %>
+    <%= form.radio_button :style, "", class: "ml-4" %>
+    <%= form.label :style_western, "設定なし" %>
+  </div>
+  <div class="mb-4">
+    <label class="block font-semibold mb-1">平日営業時間</label>
+    <%= @onsen.weekday_hours %>
+    <p class="text-sm text-gray-500 mb-2">※変更がある場合のみ入力してください</p>
+    <div class="flex items-center space-x-4">
+      <div>
+        <%= form.label :weekday_open_time, "開店:" %>
+        <%= form.time_field :weekday_open_time %>
+      </div>
+      <div>
+        <%= form.label :weekday_close_time, "閉店:" %>
+        <%= form.time_field :weekday_close_time %>
+      </div>
+    </div>
+  </div>
+  <div class="mb-4">
+    <label class="block font-semibold mb-1">土日営業時間</label>
+    <%= @onsen.weekend_hours %>
+    <p class="text-sm text-gray-500 mb-2">※変更がある場合のみ入力してください</p>
+    <div class="flex items-center space-x-4">
+      <div>
+        <%= form.label :weekend_open_time, "開店:" %>
+        <%= form.time_field :weekend_open_time %>
+      </div>
+      <div>
+        <%= form.label :weekend_close_time, "閉店:" %>
+        <%= form.time_field :weekend_close_time %>
+      </div>
+    </div>
   </div>
   <div>
-    <%= form.label :weekday_hours, "平日営業時間" %>
-    <%= form.text_field :weekday_hours, class: "block shadow-sm rounded-md border px-3 py-2 w-full border-gray-300 focus:outline-blue-600" %>
-  </div>
-  <div>
-    <%= form.label :weekend_hours, "土日営業時間" %>
-    <%= form.text_field :weekend_hours, class: "block shadow-sm rounded-md border px-3 py-2 w-full border-gray-300 focus:outline-blue-600" %>
-  </div>
-  <div>
-    <%= form.label :holiday, "定休日" %>
-    <%= form.text_field :holiday, class: "block shadow-sm rounded-md border px-3 py-2 w-full border-gray-300 focus:outline-blue-600" %>
+    <%= form.label :holiday, "定休日" %><br>
+    <% holidays = ['月','火','水','木','金','土','日'] %>
+    <% holidays.each do |holiday| %>
+      <%= check_box_tag 'onsen[holiday][]',
+        holiday,
+        @onsen.holiday.include?(holiday),
+        id: "holiday_#{holiday}" %>
+      <%= holiday %><br>
+    <% end %>
   </div>
   <div>
     <%= form.label :parking, "駐車場" %>

--- a/app/views/admin/onsens/_onsen.html.erb
+++ b/app/views/admin/onsens/_onsen.html.erb
@@ -22,7 +22,7 @@
   <dt class="font-semibold">土日営業時間</dt>
   <dd><%= onsen.weekend_hours.present? ? onsen.weekend_hours : "未設定" %></dd>
   <dt class="font-semibold">定休日</dt>
-  <dd><%= onsen.holiday.present? ? onsen.holiday : "未設定" %></dd>
+  <dd><%= onsen.holiday.any? ? onsen.holiday.join(", ") : "未設定" %></dd>
   <dt class="font-semibold">駐車場</dt>
   <dd><%= onsen.parking.present? ? onsen.parking : "なし" %></dd>
   <dt class="font-semibold">URL</dt>

--- a/app/views/onsens/_search_form.html.erb
+++ b/app/views/onsens/_search_form.html.erb
@@ -53,6 +53,33 @@
       include_blank: false,
       class: "h-8 px-2 border-gray-300 rounded" %>
     </div>
+    <%# 営業時間検索%>
+    <div>
+      <label for="search_time">営業時間</label>
+      <% if params[:search_time].present? %>
+        <p>指定された時間: <%= params[:search_time] %></p>
+      <% else %>
+        <p>指定なし</p>
+      <% end %>
+      <%= time_field_tag :search_time %>
+    </div>
+    <%# 営業曜日検索%>
+    <div class="flex items-center space-x-2">
+      <label for="open_day">営業曜日</label>
+      <%= select_tag :open_day,
+      options_for_select([
+        ['指定なし', ''],
+        ['月', '月'],
+        ['火', '火'],
+        ['水', '水'],
+        ['木', '木'],
+        ['金', '金'],
+        ['土', '土'],
+        ['日', '日']
+      ], params[:open_day]),
+      include_blank: false,
+      class: "h-8 px-2 border-gray-300 rounded" %>
+    </div>
     <%# 検索実行ボタン %>
     <div class="text-center pt-2">
       <%= f.submit t('views.onsens.index.search'),

--- a/app/views/onsens/_spot_card.html.erb
+++ b/app/views/onsens/_spot_card.html.erb
@@ -35,8 +35,10 @@
           </div>
         <% end %>
         <% if onsen.weekday_hours.present? %>
-          <span class="font-medium">平日営業時間:</span>
-          <%= onsen.weekday_hours %>
+          <div class="text-xs text-gray-500 mb-2">
+            <span class="font-medium">平日営業時間:</span>
+            <%= onsen.weekday_hours %>
+          </div>
         <% end %>
         <% if onsen.weekend_hours.present? %>
           <div class="text-xs text-gray-500 mb-2">
@@ -45,8 +47,10 @@
           </div>
         <% end %>
         <% if onsen.holiday.present? %>
-          <span class="font-medium">定休日:</span>
-          <%= onsen.holiday %>
+          <div class="text-xs text-gray-500 mb-2">
+            <span class="font-medium">定休日:</span>
+            <span><%= onsen.holiday.any? ? onsen.holiday.join(", ") : "未設定" %></span>
+          </div>
         <% end %>
         <% if onsen.parking.present? %>
           <span class="font-medium">駐車場:</span>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_28_023455) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_28_003756) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 


### PR DESCRIPTION
営業時間の登録方法をtime_fieldにして必ず00:00-23:59の形式で保存されるように変更
定休日の登録方法をチェックボックスに変更
定休日の保存方法を配列型式に変更
ユーザーが時間,曜日を入力するとその時間にやっているお店に絞り込むフィルターの追加（時間のみの場合、平日・休日営業時間のどちらかにやっていれば表示,　曜日のみの場合、その曜日にやっている店舗を表示)